### PR TITLE
fix: prevent panels from collapsing on landscape mobile

### DIFF
--- a/src/layouts/PanelsLayout/PanelsLayout.css
+++ b/src/layouts/PanelsLayout/PanelsLayout.css
@@ -28,7 +28,7 @@
   color: var(--panel-dark-text);
 }
 
-@media (min-width: 640px) {
+@media (min-width: 640px) and (min-height: 500px) {
   .panels-card {
     min-height: 0;
     height: 65vh;


### PR DESCRIPTION
Add min-height: 500px condition to the 65vh panel height media query so landscape phones (wide but short viewports) fall back to min-height: 100vh instead of rendering panels at ~250px.