### PR TITLE
feat: right-align nav links on desktop

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -37,7 +37,7 @@ export default function Nav({ onRsvpClick, view, onNavigateToLanding }: NavProps
   }
 
   return (
-    <nav className="flex sm:sticky top-0 z-50 bg-white border-b border-gray-200 px-6 py-3 items-center justify-between">
+    <nav className="flex sm:sticky top-0 z-50 bg-white border-b border-gray-200 px-6 py-3 items-center justify-center sm:justify-end">
       <ul className="flex flex-wrap gap-4 justify-center text-sm pr-20 sm:pr-0">
         <li><a href="#date-and-time" onClick={handleAnchorClick} className="hover:underline">When &amp; Where</a></li>
         <li><a href="#dress-code" onClick={handleAnchorClick} className="hover:underline">Info</a></li>


### PR DESCRIPTION
## Summary
- Nav anchor links are now right-aligned on desktop, sitting to the left of the RSVP button
- Mobile layout unchanged (links remain centered, RSVP button stays fixed top-right)

Closes #23

## Test plan
- [ ] Desktop: verify links are right-aligned with RSVP button to their right
- [ ] Mobile: verify links remain centered and RSVP button stays fixed top-right

🤖 Generated with [Claude Code](https://claude.com/claude-code)