### PR TITLE
feat: add context subtitle to song suggestion field

### DIFF
--- a/src/components/RsvpLookup.tsx
+++ b/src/components/RsvpLookup.tsx
@@ -330,6 +330,7 @@ export default function RsvpLookup({ onBack }: RsvpLookupProps) {
                     <label htmlFor="song" className="text-sm font-medium">
                       Song suggestion <span className="font-normal text-gray-500">(optional)</span>
                     </label>
+                    <p className="text-xs text-gray-500">Let us know what you want to hear on the dance floor</p>
                     <input
                       id="song"
                       type="text"
@@ -424,6 +425,7 @@ export default function RsvpLookup({ onBack }: RsvpLookupProps) {
                         >
                           Song suggestion <span className="font-normal text-gray-500">(optional)</span>
                         </label>
+                        <p className="text-xs text-gray-500">Let us know what you want to hear on the dance floor</p>
                         <input
                           id={`additionalGuests.${index}.song`}
                           type="text"


### PR DESCRIPTION
## Summary
- Added helper text "Let us know what you want to hear on the dance floor" under the song suggestion label
- Applied to both the primary guest and additional guests fields

Closes #26

## Test plan
- [ ] Open RSVP form and confirm subtitle appears under song suggestion field for primary guest
- [ ] Add an additional guest and confirm subtitle appears there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)