### PR TITLE
feat: add RSVP button to hero banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ function App() {
   return (
     <>
       <Nav onRsvpClick={() => { history.replaceState(null, '', window.location.pathname + window.location.search); setView('rsvp-lookup') }} view={view} onNavigateToLanding={() => setView('landing')} />
-      {view === 'landing' && <PanelsLayout />}
+      {view === 'landing' && <PanelsLayout onRsvpClick={() => { history.replaceState(null, '', window.location.pathname + window.location.search); setView('rsvp-lookup') }} />}
       {view === 'rsvp-lookup' && (
         <RsvpLookup onBack={() => setView('landing')} />
       )}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,8 +1,18 @@
-export default function Hero() {
+interface HeroProps {
+  onRsvpClick: () => void
+}
+
+export default function Hero({ onRsvpClick }: HeroProps) {
   return (
     <section id="hero" className="px-6 py-16 text-center">
       <h1 className="text-4xl font-light mb-4">Becky &amp; Daniel</h1>
-      <p className="text-base">12 January 2027 | Markovina Vineyard Estate</p>
+      <p className="text-base mb-8">12 January 2027 | Markovina Vineyard Estate</p>
+      <button
+        onClick={onRsvpClick}
+        className="px-6 py-2 text-sm bg-gray-900 text-white rounded hover:bg-gray-700"
+      >
+        RSVP
+      </button>
     </section>
   )
 }

--- a/src/layouts/PanelsLayout/index.tsx
+++ b/src/layouts/PanelsLayout/index.tsx
@@ -21,16 +21,24 @@ interface Panel {
 }
 
 const PANELS: Panel[] = [
-  { id: 'hero',                   Component: Hero },
-  { id: 'date-and-time',          Component: DateAndTime },
+  { id: 'date-and-time',          Component: DateAndTime, tone: 'light' },
   { id: 'dress-code',             Component: DressCodeParking, tone: 'dark' },
   { id: 'timeline',               Component: Timeline, fullWidth: true, tone: 'light' },
   { id: 'faqs',                    Component: FAQs, tone: 'dark' },
 ]
 
-export default function PanelsLayout() {
+interface PanelsLayoutProps {
+  onRsvpClick: () => void
+}
+
+export default function PanelsLayout({ onRsvpClick }: PanelsLayoutProps) {
   return (
     <div className="panels-wrapper">
+      <div className="relative panels-card panels-card--dark">
+        <div className="w-full h-full lg:max-w-5xl lg:mx-auto flex flex-col justify-center">
+          <Hero onRsvpClick={onRsvpClick} />
+        </div>
+      </div>
       {PANELS.map((panel, index) => {
         const { id, Component, image, fullWidth } = panel
         const tone = panel.tone ?? (index % 2 === 0 ? 'dark' : 'light')


### PR DESCRIPTION
## Summary
- Added RSVP button to the hero section
- Threaded `onRsvpClick` from `App` → `PanelsLayout` → `Hero`
- Pulled `Hero` out of the generic `PANELS` array so it can accept props
- Fixed panel tone for `date-and-time` after index shift

Closes #22

## Test plan
- [ ] RSVP button appears in the hero banner
- [ ] Clicking it opens the RSVP form
- [ ] Panel background colours are unchanged (hero dark, date-and-time light, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)